### PR TITLE
Attendee checking-in cleanup

### DIFF
--- a/app/src/main/java/com/example/eventsnapqr/ManageEventFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/ManageEventFragment.java
@@ -114,9 +114,8 @@ public class ManageEventFragment extends Fragment {
         });
 
         view.findViewById(R.id.qr_code_button).setOnClickListener(v -> {
-            String eventID = FirebaseController.getInstance().getUniqueEventID();
             Bundle bundle = new Bundle();
-            bundle.putString("eventId", eventID);
+            bundle.putString("eventId", eventId);
             bundle.putString("destination", "manage");
             // navigate to QR dialog fragment here
             NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);

--- a/app/src/main/java/com/example/eventsnapqr/ManageEventFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/ManageEventFragment.java
@@ -117,7 +117,10 @@ public class ManageEventFragment extends Fragment {
             String eventID = FirebaseController.getInstance().getUniqueEventID();
             Bundle bundle = new Bundle();
             bundle.putString("eventId", eventID);
+            bundle.putString("destination", "manage");
             // navigate to QR dialog fragment here
+            NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
+            navController.navigate(R.id.action_ManageEventFragment_to_qRDialogFragment, bundle);
         });
 
         view.findViewById(R.id.notify_attendee_button).setOnClickListener(v -> showNotificationDialog());

--- a/app/src/main/java/com/example/eventsnapqr/ManageEventFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/ManageEventFragment.java
@@ -1,6 +1,7 @@
 package com.example.eventsnapqr;
 
 import android.content.DialogInterface;
+import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.text.InputType;
 import android.util.Log;
@@ -21,6 +22,10 @@ import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.storage.StorageReference;
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.journeyapps.barcodescanner.BarcodeEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -97,14 +102,24 @@ public class ManageEventFragment extends Fragment {
         fetchAttendeeData();
 
         view.findViewById(R.id.button_back_button).setOnClickListener(v -> requireActivity().onBackPressed());
+
         view.findViewById(R.id.real_time_attendance_button).setOnClickListener(v -> {
             NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
             navController.navigate(R.id.action_YourEventFragment_to_RealTimeAttendanceFragment);
         });
+
         view.findViewById(R.id.attendee_map_button).setOnClickListener(v -> {
             NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
             navController.navigate(R.id.action_YourEventFragment_to_MapFragment);
         });
+
+        view.findViewById(R.id.qr_code_button).setOnClickListener(v -> {
+            String eventID = FirebaseController.getInstance().getUniqueEventID();
+            Bundle bundle = new Bundle();
+            bundle.putString("eventId", eventID);
+            // navigate to QR dialog fragment here
+        });
+
         view.findViewById(R.id.notify_attendee_button).setOnClickListener(v -> showNotificationDialog());
 
         attendeeListView.setOnItemClickListener((parent, view1, position, id) -> CreateDialog(position));

--- a/app/src/main/java/com/example/eventsnapqr/OrganizeEventFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/OrganizeEventFragment.java
@@ -157,46 +157,33 @@ public class OrganizeEventFragment extends Fragment {
             public void onUserRetrieved(User user) {
                 if (user != null) {
                     String eventID = FirebaseController.getInstance().getUniqueEventID();
-                    BarcodeEncoder barcodeEncoder = new BarcodeEncoder();
+                    Bundle bundle = new Bundle();
+                    bundle.putString("eventId", eventID);
 
-                    try {
-                        Bitmap qrBitmap = barcodeEncoder.encodeBitmap(eventID, BarcodeFormat.QR_CODE, 400, 400);
-                        if (qrBitmap != null) {
-                            Log.d("QR_CODE", "QR Code generated successfully");
-                        } else {
-                            Log.e("QR_CODE", "Failed to generate QR Code: Bitmap is null");
-                        }
-                        Bundle bundle = new Bundle();
-                        bundle.putParcelable("bitmap", qrBitmap);
-                        if (imageUri != null) {
-                            StorageReference userRef = storageRef.child("eventPosters/" + eventID);  // specifies the path on the cloud storage
-                            userRef.putFile(imageUri).addOnSuccessListener(taskSnapshot -> {
-                                userRef.getDownloadUrl().addOnSuccessListener(uri -> {
-                                    imageUri = uri;
-                                    uriString = imageUri.toString();
-                                    Event newEvent = new Event(user, eventName, eventDesc, uriString, eventMaxAttendees, eventID, announcement);
-                                    Log.d("USER NAME", newEvent.getOrganizer().getName());
-                                    firebaseController.addEvent(newEvent);
-                                    NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
-                                    navController.navigate(R.id.action_organizeEventFragment_to_qRDialogFragment, bundle);
-                                });
+                    if (imageUri != null) {
+                        StorageReference userRef = storageRef.child("eventPosters/" + eventID); // specifies the path on the cloud storage
+                        userRef.putFile(imageUri).addOnSuccessListener(taskSnapshot -> {
+                            userRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                                imageUri = uri;
+                                uriString = imageUri.toString();
+                                Event newEvent = new Event(user, eventName, eventDesc, uriString, eventMaxAttendees, eventID, announcement);
+                                Log.d("USER NAME", newEvent.getOrganizer().getName());
+                                firebaseController.addEvent(newEvent);
+                                NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
+                                navController.navigate(R.id.action_organizeEventFragment_to_qRDialogFragment, bundle);
                             });
-                        } else {
-                            uriString = null;
-                            Event newEvent = new Event(user, eventName, eventDesc, uriString, eventMaxAttendees, eventID, announcement);
-                            Log.d("USER NAME", newEvent.getOrganizer().getName());
-                            firebaseController.addEvent(newEvent);
-                            firebaseController.addOrganizedEvent(user, newEvent);
-                            NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
-                            navController.navigate(R.id.action_organizeEventFragment_to_qRDialogFragment, bundle);
-                        }
-                    } catch (WriterException e) {
-                        e.printStackTrace();
-                        Log.e("QR_CODE", "Failed to generate QR Code: " + e.getMessage());
+                        });
+                    } else {
+                        uriString = null;
+                        Event newEvent = new Event(user, eventName, eventDesc, uriString, eventMaxAttendees, eventID, announcement);
+                        Log.d("USER NAME", newEvent.getOrganizer().getName());
+                        firebaseController.addEvent(newEvent);
+                        firebaseController.addOrganizedEvent(user, newEvent);
+                        NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
+                        navController.navigate(R.id.action_organizeEventFragment_to_qRDialogFragment, bundle);
                     }
                 }
             }
         });
     }
-
 }

--- a/app/src/main/java/com/example/eventsnapqr/OrganizeEventFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/OrganizeEventFragment.java
@@ -169,6 +169,7 @@ public class OrganizeEventFragment extends Fragment {
                                 Event newEvent = new Event(user, eventName, eventDesc, uriString, eventMaxAttendees, eventID, announcement);
                                 Log.d("USER NAME", newEvent.getOrganizer().getName());
                                 firebaseController.addEvent(newEvent);
+                                bundle.putString("destination", "main");
                                 NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
                                 navController.navigate(R.id.action_organizeEventFragment_to_qRDialogFragment, bundle);
                             });

--- a/app/src/main/java/com/example/eventsnapqr/QRDialogFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/QRDialogFragment.java
@@ -68,6 +68,7 @@ public class QRDialogFragment extends DialogFragment {
         // Retrieve data from the bundle
         Bundle bundle = getArguments();
         eventId = bundle.getString("eventId");
+        Log.d("EVENT ID QR DIALOG: ", eventId);
         BarcodeEncoder barcodeEncoder = new BarcodeEncoder();
 
         try {

--- a/app/src/main/java/com/example/eventsnapqr/QRDialogFragment.java
+++ b/app/src/main/java/com/example/eventsnapqr/QRDialogFragment.java
@@ -92,9 +92,14 @@ public class QRDialogFragment extends DialogFragment {
 
         buttonExit = view.findViewById(R.id.button_exit);
         buttonExit.setOnClickListener(new View.OnClickListener() {
+            String destination = bundle.getString("destination");
             @Override
             public void onClick(View v) {
-                requireActivity().finish();
+                if (destination.equals("manage")) {
+                    requireActivity().onBackPressed();
+                } else if (destination.equals("main")) {
+                    requireActivity().finish();
+                }
             }
         });
 

--- a/app/src/main/java/com/example/eventsnapqr/ScanQRActivity.java
+++ b/app/src/main/java/com/example/eventsnapqr/ScanQRActivity.java
@@ -87,10 +87,17 @@ public class ScanQRActivity extends AppCompatActivity {
                         NavController navController = Navigation.findNavController(ScanQRActivity.this, R.id.nav_host_fragment);
                         Bundle bundle = new Bundle();
                         bundle.putString("eventId", eventId);
-                        navController.navigate(R.id.eventDetailsFragment, bundle);
+                        // navController.navigate(R.id.eventDetailsFragment, bundle);
                     })
                     .setNegativeButton("Return", new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int id) {
+                            finish();
+                        }
+                    })
+                    .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                        @Override
+                        public void onDismiss(DialogInterface dialog) {
+                            // finish activity if dialog is dismissed without button press
                             finish();
                         }
                     })
@@ -114,9 +121,16 @@ public class ScanQRActivity extends AppCompatActivity {
                     public void onEventRetrieved(Event event) {
                         if (event != null) {
                             AlertDialog.Builder builder = new AlertDialog.Builder(ScanQRActivity.this);
-                            builder.setTitle("You have checked into " + event.getEventName() + " for the " + count + getSuffix(count) + " time")
+                            builder.setTitle("You have checked into " + event.getEventName() + " for the " + count + getSuffix(count) + " time!")
                                     .setPositiveButton("OK", new DialogInterface.OnClickListener() {
                                         public void onClick(DialogInterface dialog, int id) {
+                                            finish();
+                                        }
+                                    })
+                                    .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                                        @Override
+                                        public void onDismiss(DialogInterface dialog) {
+                                            // Finish activity if dialog is dismissed without button press
                                             finish();
                                         }
                                     });
@@ -126,6 +140,13 @@ public class ScanQRActivity extends AppCompatActivity {
                             builder.setMessage("Failed to retrieve event details.")
                                     .setPositiveButton("OK", new DialogInterface.OnClickListener() {
                                         public void onClick(DialogInterface dialog, int id) {
+                                            finish();
+                                        }
+                                    })
+                                    .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                                        @Override
+                                        public void onDismiss(DialogInterface dialog) {
+                                            // finish activity if dialog is dismissed without button press
                                             finish();
                                         }
                                     });
@@ -143,12 +164,18 @@ public class ScanQRActivity extends AppCompatActivity {
                             public void onClick(DialogInterface dialog, int id) {
                                 finish();
                             }
+                        })
+                        .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                            @Override
+                            public void onDismiss(DialogInterface dialog) {
+                                // Finish activity if dialog is dismissed without user interaction
+                                finish();
+                            }
                         });
                 builder.create().show();
             }
         });
     }
-
 
     /**
      * returns the correct suffix for the given integer
@@ -207,9 +234,14 @@ public class ScanQRActivity extends AppCompatActivity {
                         Log.e(TAG, "User in Event attendees check failed: " + e.getMessage()); // Log if there's an error
                     }
                 });
+            } else {
+                // case when no QR code was scanned before camera closed
+                Log.d(TAG, "No QR code scanned before camera closed");
+                finish(); // finish the activity if no QR code was scanned before camera closed
             }
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
     }
+
 }

--- a/app/src/main/res/layout/fragment_q_r_dialog.xml
+++ b/app/src/main/res/layout/fragment_q_r_dialog.xml
@@ -8,8 +8,6 @@
     android:weightSum="1"
     android:layout_gravity="center">
 
-    <!-- TODO: Update blank fragment layout -->
-
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -30,7 +28,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="#FFFFFF"
-            android:text="Exit to main" />
+            android:text="Return" />
         <Space
             android:layout_width="26dp"
             android:layout_height="wrap_content" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -96,6 +96,9 @@
             android:id="@+id/action_YourEventFragment_to_RealTimeAttendanceFragment"
             app:destination="@id/RealTimeAttendanceFragment"
             />
+        <action
+            android:id="@+id/action_ManageEventFragment_to_qRDialogFragment"
+            app:destination="@id/qRDialogFragment"/>
     </fragment>
     <fragment
         android:id="@+id/RealTimeAttendanceFragment"
@@ -150,13 +153,7 @@
             android:id="@+id/action_adminBrowseImagesFragment_to_AdminModeMainPageFragment"
             app:destination="@id/adminModeMainPageFragment" />
     </fragment>
-    <fragment
-        android:id="@+id/scanCameraFragment"
-        android:name="com.example.eventsnapqr.ScanCameraFragment"
-        android:label="Scan QR Activity"
-        tools:layout="@layout/fragment_scan_camera">
 
-    </fragment>
     <fragment
         android:id="@+id/adminBrowseEventsFragment"
         android:name="com.example.eventsnapqr.AdminBrowseEventsFragment"


### PR DESCRIPTION
- Can now view QR code from the manageEventsPage, no need to create an event to view a qr code now
- QR is no longer generated in organizeNewEvent, but rather the QRdialog fragment
- Fixed bug where qr scanning could lead to a blank activity
- View event details option when not signed up still crashes the app, as it needs proper navigation implemented